### PR TITLE
ARC64: Select arc64 target for real

### DIFF
--- a/scripts/build/arch/arc.sh
+++ b/scripts/build/arch/arc.sh
@@ -2,8 +2,19 @@
 
 CT_DoArchTupleValues()
 {
-    # The architecture part of the tuple:
-    CT_TARGET_ARCH="${CT_ARCH}${CT_ARCH_SUFFIX:-${target_endian_eb}}"
+    case "${CT_ARCH_BITNESS}" in
+        32)
+            CT_TARGET_ARCH="${CT_ARCH}${CT_ARCH_SUFFIX:-${target_endian_eb}}"
+            ;;
+        64)
+            # arc64 is little-endian only for now
+            # and thus "-mlittle-endian" option in GCC is obsolete for arc64
+            CT_TARGET_ARCH="arc64${CT_ARCH_SUFFIX}"
+            CT_ARCH_ENDIAN_CFLAG=""
+            # The same goes to the linker - we only build for little-endian.
+            CT_ARCH_ENDIAN_LDFLAG=""
+            ;;
+    esac
 }
 
 CT_DoArchUClibcConfig()


### PR DESCRIPTION
W/o this part GCC gets configured by default fro building 32-bit code. I.e. what was built with a previous changes in the end was cross GCC for 32-bit ARC.

Now fix it by adding missing part and explicitly set CT_TARGET_ARCH to arc64 if 64-bit target is selected.