### PR TITLE
newlib: Change ftp mirror link to https one

### DIFF
--- a/packages/newlib-nano/package.desc
+++ b/packages/newlib-nano/package.desc
@@ -2,7 +2,7 @@ origin='RedHat'
 repository='git git://sourceware.org/git/newlib-cygwin.git'
 # Do not use "$(CT_Mirrors sourceware newlib)" here: the mirrors (kernel.org
 # and gnu.org) only store some older releases of newlib (2.0.0 and before).
-mirrors='ftp://sourceware.org/pub/newlib'
+mirrors='https://sourceware.org/pub/newlib'
 relevantpattern='*.*|.*. *.*|.'
 archive_filename='newlib-@{version}'
 archive_dirname='newlib-@{version}'

--- a/packages/newlib/package.desc
+++ b/packages/newlib/package.desc
@@ -2,6 +2,6 @@ origin='RedHat'
 repository='git git://sourceware.org/git/newlib-cygwin.git'
 # Do not use "$(CT_Mirrors sourceware newlib)" here: the mirrors (kernel.org
 # and gnu.org) only store some older releases of newlib (2.0.0 and before).
-mirrors='ftp://sourceware.org/pub/newlib'
+mirrors='https://sourceware.org/pub/newlib'
 relevantpattern='*.*|.*. *.*|.'
 archive_formats='.tar.gz'


### PR DESCRIPTION
Some corporate VPN services block ftp connections. It leads to an error while building a toolchain with packages with ftp mirrors. It's possible to safely use https instead of ftp.