### PR TITLE
Fix Crosstool-NG after Picolibc 1.8.11 release

### DIFF
--- a/config/comp_libs/picolibc-nano.in
+++ b/config/comp_libs/picolibc-nano.in
@@ -35,29 +35,63 @@ config LIBC_PICOLIBC_NANO_IO_LL
 
 config LIBC_PICOLIBC_NANO_REGISTER_FINI
     bool
-    prompt "Enable finalization function registration using atexit"
+    prompt "Enable finalization function registration using atexit [unused]"
     help
         Enable finalization function registration using atexit.
 
+	This would be used when building with the legacy newlib exit
+	handling code which cannot be enabled in crosstool-ng, so
+	this option doesn't do anything.
+
 config LIBC_PICOLIBC_NANO_ATEXIT_DYNAMIC_ALLOC
     bool
-    prompt "Enable dynamic allocation of atexit entries"
+    prompt "Enable dynamic allocation of atexit entries [unused]"
     help
         Enable dynamic allocation of atexit entries.
 
+	This would be used when building with the legacy newlib exit
+	handling code which cannot be enabled in crosstool-ng, so
+
 config LIBC_PICOLIBC_NANO_GLOBAL_ATEXIT
     bool
-    prompt "Enable atexit data structure as global variable"
+    prompt "Enable atexit data structure as global variable [unused]"
     help
         Enable atexit data structure as global variable, instead
         of being thread-local.
 
-config LIBC_PICOLIBC_NANO_SINGLE_THREAD
+	This would be used when building with the legacy newlib exit
+	handling code which cannot be enabled in crosstool-ng, so
+	this option doesn't do anything.
+
+config LIBC_PICOLIBC_NANO_LITE_EXIT
     bool
-    prompt "Disable support for multiple threads"
-    default n
+    prompt "Enable lite exit [unused]"
+    default y
     help
-        Disable support for multiple threads.
+        Enable lite exit, a size-reduced implementation of exit that doesn't
+        invoke clean-up functions such as _fini or global destructors.
+
+	This would be used when building with the legacy newlib exit
+	handling code which cannot be enabled in crosstool-ng, so
+	this option doesn't do anything.
+
+config LIBC_PICOLIBC_NANO_MULTITHREAD
+    bool
+    prompt "Enable support for multiple threads"
+    default y
+    help
+        Enable support for multiple threads.
+
+config LIBC_PICOLIBC_NANO_RETARGETABLE_LOCKING
+    bool
+    prompt "Enable retargetable locking [unused]"
+    default y
+    help
+        Enable retargetable locking to allow the operating system to override
+        the dummy lock functions defined within picolibc.
+
+	This value was always required to match
+	LIBC_PICOLIBC_NANO_MULTITHREAD, so it is no longer used.
 
 config LIBC_PICOLIBC_NANO_EXTRA_SECTIONS
     bool
@@ -75,17 +109,6 @@ config LIBC_PICOLIBC_NANO_LTO
       optimization. You will need to add -flto-partition=one to your
       application's link line to keep the RETURN assembler macro together
       with it's consumers.
-
-config LIBC_PICOLIBC_NANO_NANO_MALLOC
-    bool
-    prompt "Enable Nano Malloc"
-    default y
-    help
-      PICOLIBC has two implementations of malloc family's functions, one in
-      `mallocr.c' and the other one in `nano-mallocr.c'.  This options
-      enables the nano-malloc implementation, which is for small systems
-      with very limited memory.  Note that this implementation does not
-      support `--enable-malloc-debugging' any more.
 
 config LIBC_PICOLIBC_NANO_OBSOLETE_FLOAT
     bool

--- a/config/libc/picolibc.in
+++ b/config/libc/picolibc.in
@@ -123,17 +123,6 @@ config LIBC_PICOLIBC_LTO
       application's link line to keep the RETURN assembler macro together
       with it's consumers.
 
-config LIBC_PICOLIBC_NANO_MALLOC
-    bool
-    prompt "Enable Nano Malloc"
-    default y
-    help
-      PICOLIBC has two implementations of malloc family's functions, one in
-      `mallocr.c' and the other one in `nano-mallocr.c'.  This options
-      enables the nano-malloc implementation, which is for small systems
-      with very limited memory.  Note that this implementation does not
-      support `--enable-malloc-debugging' any more.
-
 config LIBC_PICOLIBC_OBSOLETE_FLOAT
     bool
     prompt "Always use obsolete math for 32-bit FPU"

--- a/scripts/build/companion_libs/340-picolibc.sh
+++ b/scripts/build/companion_libs/340-picolibc.sh
@@ -26,7 +26,6 @@ do_picolibc_common_install() {
 
     yn_args="IO_C99FMT:io-c99-formats
 IO_LL:io-long-long
-NANO_MALLOC:newlib-nano-malloc
     "
 
     for ynarg in $yn_args; do

--- a/scripts/build/companion_libs/340-picolibc.sh
+++ b/scripts/build/companion_libs/340-picolibc.sh
@@ -89,8 +89,10 @@ cpu_family = '${CT_TARGET_ARCH}'
 cpu = '${CT_TARGET_ARCH}'
 endian = 'little'
 
-[properties]
+[built-in options]
 c_args = [ ${meson_cflags} '-nostdlib', '-fno-common', '-ftls-model=local-exec' ]
+
+[properties]
 needs_exe_wrapper = true
 skip_sanity_check = true
 default_flash_addr = '${CT_LIBC_PICOLIBC_DEFAULT_FLASH_ADDR}'

--- a/scripts/build/companion_libs/341-picolibc_nano.sh
+++ b/scripts/build/companion_libs/341-picolibc_nano.sh
@@ -110,11 +110,6 @@ do_picolibc_nano_for_target() {
 
     yn_args="IO_C99FMT:io-c99-formats
 IO_LL:io-long-long
-REGISTER_FINI:newlib-register-fini
-NANO_MALLOC:newlib-nano-malloc
-ATEXIT_DYNAMIC_ALLOC:newlib-atexit-dynamic-alloc
-GLOBAL_ATEXIT:newlib-global-atexit
-SINGLE_THREAD:single-thread
     "
 
     for ynarg in $yn_args; do
@@ -129,6 +124,25 @@ SINGLE_THREAD:single-thread
             picolibc_nano_opts+=( "-D$argument=false" )
         fi
     done
+
+
+    # Check how picolibc wants threading support to be specified
+
+    if grep -q single-thread "${CT_SRC_DIR}/picolibc/meson_options.txt"; then
+	if [ "${CT_LIBC_PICOLIBC_NANO_MULTITHREAD}" = "y" ]; then
+	    picolibc_nano_opts+=("-Dsingle-thread=false")
+	else
+	    picolibc_nano_opts+=("-Dsingle-thread=true")
+	fi
+    else
+	if [ "${CT_LIBC_PICOLIBC_NANO_MULTITHREAD}" = "y" ]; then
+	    picolibc_nano_opts+=("-Dnewlib-retargetable-locking=true")
+	    picolibc_nano_opts+=("-Dnewlib-multithread=true")
+	else
+	    picolibc_nano_opts+=("-Dnewlib-retargetable-locking=false")
+	    picolibc_nano_opts+=("-Dnewlib-multithread=false")
+	fi
+    fi
 
     [ "${CT_LIBC_PICOLIBC_NANO_EXTRA_SECTIONS}" = "y" ] && \
         CT_LIBC_PICOLIBC_NANO_TARGET_CFLAGS="${CT_LIBC_PICOLIBC_NANO_TARGET_CFLAGS} -ffunction-sections -fdata-sections"

--- a/scripts/build/companion_libs/341-picolibc_nano.sh
+++ b/scripts/build/companion_libs/341-picolibc_nano.sh
@@ -174,8 +174,10 @@ cpu_family = '${CT_TARGET_ARCH}'
 cpu = '${CT_TARGET_ARCH}'
 endian = 'little'
 
-[properties]
+[built-in options]
 c_args = [ ${meson_cflags} '-nostdlib', '-fno-common', '-ftls-model=local-exec' ]
+
+[properties]
 needs_exe_wrapper = true
 skip_sanity_check = true
 default_flash_addr = '${CT_LIBC_PICOLIBC_DEFAULT_FLASH_ADDR}'

--- a/scripts/build/libc/picolibc.sh
+++ b/scripts/build/libc/picolibc.sh
@@ -14,8 +14,15 @@ picolibc_extract()
 
 picolibc_headers()
 {
+    local headers_dir="${CT_SRC_DIR}/picolibc/newlib/libc/include/."
+
+    # In Picolibc 1.8.11 intermediate "newlib" directory was removed
+    if [ ! -d "${headers_dir}" ]; then
+        headers_dir="${CT_SRC_DIR}/picolibc/libc/include/."
+    fi
+
     CT_DoStep INFO "Installing C library headers"
-    CT_DoExecLog ALL cp -a "${CT_SRC_DIR}/picolibc/newlib/libc/include/." "${CT_HEADERS_DIR}"
+    CT_DoExecLog ALL cp -a "${headers_dir}" "${CT_HEADERS_DIR}"
     CT_EndStep
 }
 


### PR DESCRIPTION
After updating Picolibc to 1.8.11 we need to adjust Crosstool-NG. All commits of this PR fix issues related to obsolete options and synchronization of options between Picolibc and Picolibc Nano scripts.