### PR TITLE
picolibc: Do not use RISC-V features in general code

### DIFF
--- a/config/comp_libs/picolibc-nano.in
+++ b/config/comp_libs/picolibc-nano.in
@@ -8,7 +8,7 @@
 config LIBC_PICOLIBC_NANO_TARGET_CFLAGS
     string
     prompt "Target CFLAGS for picolibc"
-    default "-Os -msave-restore"
+    default "-Os"
     help
       Used to add specific options when compiling the target libraries
       (eg. -ffunction-sections -fdata-sections), which can't be defined
@@ -113,6 +113,7 @@ config LIBC_PICOLIBC_NANO_LTO
 config LIBC_PICOLIBC_NANO_OBSOLETE_FLOAT
     bool
     prompt "Always use obsolete math for 32-bit FPU"
+    depends on ARCH_RISCV
     default n
     help
       Use obsolete math for targets with 32-bit FPU (FLEN < 64 or
@@ -139,7 +140,7 @@ config LIBC_PICOLIBC_NANO_GCC_LIBSTDCXX
 config LIBC_PICOLIBC_NANO_GCC_LIBSTDCXX_TARGET_CXXFLAGS
     string
     prompt "Target CXXFLAGS for libstdc++ picolibc-nano variant"
-    default "-fno-exceptions -msave-restore"
+    default "-fno-exceptions"
     depends on LIBC_PICOLIBC_NANO_GCC_LIBSTDCXX
     help
       Used to add extra CXXFLAGS when compiling the target libstdc++

--- a/config/libc/picolibc.in
+++ b/config/libc/picolibc.in
@@ -126,6 +126,7 @@ config LIBC_PICOLIBC_LTO
 config LIBC_PICOLIBC_OBSOLETE_FLOAT
     bool
     prompt "Always use obsolete math for 32-bit FPU"
+    depends on ARCH_RISCV
     default n
     help
       Use obsolete math for targets with 32-bit FPU (FLEN < 64 or


### PR DESCRIPTION
1. LIBC_PICOLIBC_OBSOLETE_FLOAT and LIBC_PICOLIBC_NANO OBSOLETE_FLOAT options works correctly only with RISC-V targets yet. Make them dependent on ARCH_RISCV.
2. Do not pass -msave-restore for C++ libraries for Picolibc Nano configuration.