### PR TITLE
gcc: Allow CC_GCC_MULTILIB_LIST for RISC-V baremetal.

### DIFF
--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -80,7 +80,6 @@ config CC_GCC_EXTRA_CONFIG_ARRAY
 config CC_GCC_MULTILIB_LIST
     string "List of multilib variants"
     depends on MULTILIB
-    depends on ! (ARCH_RISCV && BARE_METAL)
     default "m2,m2e,m4,m4-single,m4-single-only,m2a,m2a-single" if GCC_11_or_later && ARCH_SH
     default "aprofile,rmprofile" if ARCH_ARM && ARCH_32
     help


### PR DESCRIPTION
Remove the restriction preventing CC_GCC_MULTILIB_LIST from being used with RISC-V baremetal targets.  This is needed for PR testing which requires --with-multilib-list=reduced for faster builds.